### PR TITLE
Unclosed client session fix

### DIFF
--- a/animal/animal.py
+++ b/animal/animal.py
@@ -22,7 +22,7 @@ class Animal(BaseCog):
 
     def __init__(self, bot):
         self.bot = bot
-        self.session = aiohttp.ClientSession(loop=self.bot.loop)
+        self.session = aiohttp.ClientSession()
         self.catapi = catapi
         self.dogapi = dogapi
         self.foxapi = foxapi

--- a/doujin/doujin.py
+++ b/doujin/doujin.py
@@ -17,7 +17,7 @@ class Doujin(BaseCog):
 
     def __init__(self, bot):
         self.bot = bot
-        self.session = aiohttp.ClientSession(loop=self.bot.loop)
+        self.session = aiohttp.ClientSession()
 
     @commands.group(autohelp=True)
     @commands.guild_only()


### PR DESCRIPTION
Restarting Red throws an unclosed connection error, after some testing, removing the loop arg from the ClientSession creation seems to solve the issue.
This seems to be the correct way of doing this because the loop arg is a Deprecated arg
( also cross-checking with aikaterna's cogs ([example](https://github.com/aikaterna/aikaterna-cogs/blob/eec578a94c98208a52275d5f9bcbdde48c87db92/dictionary/dictionary.py#L22)) , this is what is done there (without the loop arg))

Error:
```
[2021-01-07 14:41:53] [INFO] red.main: Please wait, cleaning up a bit more
/data/cogs/CogManager/cogs/animal/animal.py:148: RuntimeWarning: coroutine 'ClientSession.close' was never awaited
  self.bot.loop.create_task(self.session.close())
RuntimeWarning: Enable tracemalloc to get the object allocation traceback
Exception ignored in: <function Animal.cog_unload at 0x7facbf5eff70>
Traceback (most recent call last):
  File "/data/cogs/CogManager/cogs/animal/animal.py", line 148, in cog_unload
    self.bot.loop.create_task(self.session.close())
  File "uvloop/loop.pyx", line 1394, in uvloop.loop.Loop.create_task
  File "uvloop/loop.pyx", line 668, in uvloop.loop.Loop._check_closed
RuntimeError: Event loop is closed
[2021-01-07 14:41:55] [CRITICAL] red.main: Caught unhandled exception in task: Unclosed client session
/data/cogs/CogManager/cogs/animal/animal.py:148: RuntimeWarning: coroutine 'ClientSession.close' was never awaited
  self.bot.loop.create_task(self.session.close())
RuntimeWarning: Enable tracemalloc to get the object allocation traceback
Exception ignored in: <function Animal.cog_unload at 0x7facd19568b0>
Traceback (most recent call last):
  File "/data/cogs/CogManager/cogs/animal/animal.py", line 148, in cog_unload
    self.bot.loop.create_task(self.session.close())
  File "uvloop/loop.pyx", line 1394, in uvloop.loop.Loop.create_task
  File "uvloop/loop.pyx", line 668, in uvloop.loop.Loop._check_closed
RuntimeError: Event loop is closed
```
( correcting it on every cog because why not ?)