### PR TITLE
Fix for FOX-API. (wohlsoft.ru)

### DIFF
--- a/animal/animal.py
+++ b/animal/animal.py
@@ -27,7 +27,7 @@ class Animal(BaseCog):
         self.session = aiohttp.ClientSession()
         self.catapi = "https://shibe.online/api/cats"
         self.dogapi = "https://dog.ceo/api/breeds/image/random"
-        self.foxapi = "http://wohlsoft.ru/images/foxybot/randomfox.php"
+        self.foxapi = "https://wohlsoft.ru/images/foxybot/randomfox.php"
         self.dog_breed_api = "https://dog.ceo/api/breed/{}/images/random"
         self.error_message = "An API error occured. Probably just a hiccup.\nIf this error persist for several days, please report it."
 


### PR DESCRIPTION
Animal Cog wont send Fox images from the API at the moment.. It gives an error.
wohlsoft.ru Was originally HTTP, but now allows HTTPS.   Enabling that allows the Cog to get fox images again instead of throwing the self.error_message. Thanks for the cog! Hopefully fixes for everyone else, as it did for me.